### PR TITLE
add support for background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ type Client interface {
 	// Submits a new job to the server with the specified function and payload. You must provide two
 	// WriteClosers for data and warnings to be written to.
 	Submit(fn string, payload []byte, data, warnings io.WriteCloser) (job.Job, error)
+	SubmitBackground(fn string, payload []byte) error
 }
 ```
 

--- a/packet/README.md
+++ b/packet/README.md
@@ -63,6 +63,8 @@ const (
 	WorkComplete = 13
 	// WorkFail = WORK_FAIL
 	WorkFail = 14
+	// SubmitJobBg = SUBMIT_JOB_BG
+	SubmitJobBg = 18
 	// WorkData = WORK_DATA
 	WorkData = 28
 	// WorkWarning = WORK_WARNING

--- a/packet/types.go
+++ b/packet/types.go
@@ -14,6 +14,8 @@ const (
 	WorkComplete = 13
 	// WorkFail = WORK_FAIL
 	WorkFail = 14
+	// SubmitJobBg = SUBMIT_JOB_BG
+	SubmitJobBg = 18
 	// WorkData = WORK_DATA
 	WorkData = 28
 	// WorkWarning = WORK_WARNING


### PR DESCRIPTION
Right now, this library only supports sending foreground jobs. We want to also support sending background jobs.

This is a breaking API change. I want to make some additional refactors before publishing. This code is pretty not-idiomatic, so I want to do some refactors while I'm doing a breaking API change anyway.