### PR TITLE
better go idioms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-PKG := gopkg.in/Clever/gearman.v1
+PKG := gopkg.in/Clever/gearman.v2
 SUBPKGSREL := $(shell ls -d */)
 SUBPKGS := $(addprefix $(PKG)/, $(SUBPKGSREL))
 READMES := $(addsuffix README.md, $(SUBPKGSREL))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gearman
 --
-    import "gopkg.in/Clever/gearman.v1"
+    import "gopkg.in/Clever/gearman.v2"
 
 Package gearman provides a thread-safe Gearman client
 
@@ -13,8 +13,7 @@ from that job:
     package main
 
     import(
-    	"gopkg.in/Clever/gearman.v1"
-    	"gopkg.in/Clever/gearman.v1/job"
+    	"gopkg.in/Clever/gearman.v2"
     	"ioutil"
     )
 
@@ -42,13 +41,7 @@ from that job:
 #### type Client
 
 ```go
-type Client interface {
-	// Closes the connection to the server
-	Close() error
-	// Submits a new job to the server with the specified function and payload. You must provide two
-	// WriteClosers for data and warnings to be written to.
-	Submit(fn string, payload []byte, data, warnings io.WriteCloser) (job.Job, error)
-	SubmitBackground(fn string, payload []byte) error
+type Client struct {
 }
 ```
 
@@ -57,6 +50,29 @@ Client is a Gearman client
 #### func  NewClient
 
 ```go
-func NewClient(network, addr string) (Client, error)
+func NewClient(network, addr string) (*Client, error)
 ```
 NewClient returns a new Gearman client pointing at the specified server
+
+#### func (*Client) Close
+
+```go
+func (c *Client) Close() error
+```
+Close terminates the connection to the server
+
+#### func (*Client) Submit
+
+```go
+func (c *Client) Submit(fn string, payload []byte, data, warnings io.WriteCloser) (*job.Job, error)
+```
+Submit sends a new job to the server with the specified function and payload.
+You must provide two WriteClosers for data and warnings to be written to.
+
+#### func (*Client) SubmitBackground
+
+```go
+func (c *Client) SubmitBackground(fn string, payload []byte) error
+```
+SubmitBackground submits a background job. There is no access to data, warnings,
+or completion state.

--- a/client_test.go
+++ b/client_test.go
@@ -2,12 +2,13 @@ package gearman
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/Clever/gearman.v1/job"
-	"gopkg.in/Clever/gearman.v1/packet"
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/Clever/gearman.v2/job"
+	"gopkg.in/Clever/gearman.v2/packet"
 )
 
 type bufferCloser struct {
@@ -18,12 +19,12 @@ func (buf *bufferCloser) Close() error {
 	return nil
 }
 
-func mockClient() *client {
-	c := &client{
+func mockClient() *Client {
+	c := &Client{
 		conn:    &bufferCloser{},
 		packets: make(chan *packet.Packet),
 		// Add buffers to prevent blocking in test cases
-		newJobs:     make(chan job.Job, 10),
+		newJobs:     make(chan *job.Job, 10),
 		jobs:        make(map[string]chan *packet.Packet, 10),
 		partialJobs: make(chan *partialJob, 10),
 	}
@@ -65,7 +66,7 @@ func TestJobCreated(t *testing.T) {
 	c.partialJobs <- &partialJob{nil, nil}
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	var j job.Job
+	var j *job.Job
 	var packets chan *packet.Packet
 	go func() {
 		defer wg.Done()

--- a/doc.go
+++ b/doc.go
@@ -8,8 +8,7 @@ Here's an example program that submits a job to Gearman and listens for events f
 	package main
 
 	import(
-		"gopkg.in/Clever/gearman.v1"
-		"gopkg.in/Clever/gearman.v1/job"
+		"gopkg.in/Clever/gearman.v2"
 		"ioutil"
 	)
 

--- a/job/README.md
+++ b/job/README.md
@@ -1,6 +1,6 @@
 # job
 --
-    import "gopkg.in/Clever/gearman.v1/job"
+    import "gopkg.in/Clever/gearman.v2/job"
 
 
 ## Usage
@@ -8,13 +8,7 @@
 #### type Job
 
 ```go
-type Job interface {
-	// The handle of the job
-	Handle() string
-	// Status returns the current status of the gearman job
-	Status() Status
-	// Blocks until the job completes. Returns the state, Completed or Failed.
-	Run() State
+type Job struct {
 }
 ```
 
@@ -23,12 +17,33 @@ Job represents a Gearman job
 #### func  New
 
 ```go
-func New(handle string, data, warnings io.WriteCloser, packets chan *packet.Packet) Job
+func New(handle string, data, warnings io.WriteCloser, packets chan *packet.Packet) *Job
 ```
 New creates a new Gearman job with the specified handle, updating the job based
 on the packets in the packets channel. The only packets coming down packets
 should be packets for this job. It also takes in two WriteClosers to right job
 data and warnings to.
+
+#### func (Job) Handle
+
+```go
+func (j Job) Handle() string
+```
+Handle returns job handle
+
+#### func (*Job) Run
+
+```go
+func (j *Job) Run() State
+```
+Run blocks until the job completes. Returns the state, Completed or Failed.
+
+#### func (Job) Status
+
+```go
+func (j Job) Status() Status
+```
+Status returns the current status of the gearman job
 
 #### type State
 

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -1,11 +1,12 @@
 package job
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/Clever/gearman.v1/packet"
-	"gopkg.in/Clever/gearman.v1/utils"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/Clever/gearman.v2/packet"
+	"gopkg.in/Clever/gearman.v2/utils"
 )
 
 func statusPacket(handle string, num, den int) *packet.Packet {

--- a/packet/README.md
+++ b/packet/README.md
@@ -1,6 +1,6 @@
 # packet
 --
-    import "gopkg.in/Clever/gearman.v1/packet"
+    import "gopkg.in/Clever/gearman.v2/packet"
 
 
 ## Usage

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -1,6 +1,6 @@
 # scanner
 --
-    import "gopkg.in/Clever/gearman.v1/scanner"
+    import "gopkg.in/Clever/gearman.v2/scanner"
 
 
 ## Usage

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -2,9 +2,10 @@ package scanner
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/Clever/gearman.v1/packet"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/Clever/gearman.v2/packet"
 )
 
 func packetWithArgs(args [][]byte) *packet.Packet {

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,6 +1,6 @@
 # utils
 --
-    import "gopkg.in/Clever/gearman.v1/utils"
+    import "gopkg.in/Clever/gearman.v2/utils"
 
 
 ## Usage


### PR DESCRIPTION
A core idea of Go is that you should return types and take in interfaces.

Currently, we're returning interfaces. There's not really any reason for this, it just makes us less flexible - e.g. adding a method to an interface is a breaking change, adding a method to a type is not.